### PR TITLE
Add Satellite integration

### DIFF
--- a/Sources/VGSShowSDK/Core/APIClient/APIClient.swift
+++ b/Sources/VGSShowSDK/Core/APIClient/APIClient.swift
@@ -7,20 +7,24 @@
 
 import Foundation
 
+/// Holds base API client logic.
 internal class APIClient {
 
 	typealias RequestCompletion = ((_ response: APIRequestResult) -> Void)?
 
 	// MARK: - Constants
 
-	enum Constants {
+	/// Constants.
+	internal enum Constants {
 		static let validStatuses: Range<Int> = 200..<300
 	}
 
 	// MARK: - Vars
 
-	var customHeader: VGSHTTPHeaders?
+	/// Custom headers.
+	internal var customHeader: VGSHTTPHeaders?
 
+	/// Default request headers with vgs client info.
 	internal static let defaultHttpHeaders: VGSHTTPHeaders = {
 			// Add Headers
 		let version = ProcessInfo.processInfo.operatingSystemVersion
@@ -38,9 +42,13 @@ internal class APIClient {
 	/// URLSession object.
 	internal let urlSession = URLSession(configuration: .ephemeral)
 
+	/// Vault ID.
 	private let vaultId: String
+
+	/// Vault URL.
 	private let vaultUrl: URL?
 
+	/// Base URL depends on current api policy.
 	internal var baseURL: URL? {
 		return self.hostURLPolicy.url
 	}
@@ -51,17 +59,44 @@ internal class APIClient {
 	/// Serial queue for syncing requests on resolving hostname flow.
 	private let dataSyncQueue: DispatchQueue = .init(label: "iOS.VGSShowSDK.ResolveHostNameRequestsQueue")
 
+	/// Sync semaphore.
 	private let syncSemaphore: DispatchSemaphore = .init(value: 1)
 
 	// MARK: - Initialization
 
-	required init(tenantId: String, regionalEnvironment: String, hostname: String?) {
+	/// Initialization.
+	/// - Parameters:
+	///   - tenantId: `String` object, should be valid tenant id.
+	///   - regionalEnvironment: `String` object, should be valid environment.
+	///   - hostname: `String?` object, should be valid hostname or `nil`.
+	///   - satellitePort: `Int?` object, custom port for satellite configuration. **IMPORTANT! Use only with .sandbox environment!**.
+	required internal init(tenantId: String, regionalEnvironment: String, hostname: String?, satellitePort: Int?) {
 		self.vaultUrl = VGSShow.generateVaultURL(tenantId: tenantId, regionalEnvironment: regionalEnvironment)
 		self.vaultId = tenantId
 
 		guard let validVaultURL = vaultUrl else {
 			// Cannot resolve hostname with invalid Vault URL.
 			self.hostURLPolicy = .invalidVaultURL
+			return
+		}
+
+		// Check satellite port is *nil* for regular API flow.
+		guard satellitePort == nil else {
+			// Try to build satellite URL.
+			guard let port = satellitePort, let satelliteURL = VGSShowSatelliteUtils.buildSatelliteURL(with: regionalEnvironment, hostname: hostname, satellitePort: port) else {
+
+				// Use vault URL as fallback if cannot resolve satellite flow.
+				self.hostURLPolicy = .vaultURL(validVaultURL)
+				return
+			}
+
+			// Use satellite URL and return.
+			self.hostURLPolicy = .satelliteURL(satelliteURL)
+
+			let message = "Satellite has been configured successfully! Satellite URL is: \(satelliteURL.absoluteString)"
+			let event = VGSLogEvent(level: .info, text: message)
+			VGSLogger.shared.forwardLogEvent(event)
+
 			return
 		}
 
@@ -85,7 +120,7 @@ internal class APIClient {
 
 	// MARK: - Public
 
-	func sendRequestWithJSON(path: String, method: VGSHTTPMethod = .post, value: VGSJSONData?, completion block: RequestCompletion) {
+	internal func sendRequestWithJSON(path: String, method: VGSHTTPMethod = .post, value: VGSJSONData?, completion block: RequestCompletion) {
 
 		let payload = VGSRequestPayloadBody.json(value)
 		resolveURLForRequest(path: path, method: method, payload: payload, block: block)
@@ -103,9 +138,15 @@ internal class APIClient {
 
 		let url: URL?
 
+		let infoEventText = "API will start request with current URL policy: \(hostURLPolicy.description)"
+		let infoEvent = VGSLogEvent(level: .info, text: infoEventText)
+		VGSLogger.shared.forwardLogEvent(infoEvent)
+
 		switch hostURLPolicy {
 		case .invalidVaultURL:
 			url = nil
+		case .satelliteURL(let satelliteURL):
+			url = satelliteURL
 		case .vaultURL(let vaultURL):
 			url = vaultURL
 		case .customHostURL(let status):

--- a/Sources/VGSShowSDK/Core/APIClient/APIHostName/APICustomHostStatus.swift
+++ b/Sources/VGSShowSDK/Core/APIClient/APIHostName/APICustomHostStatus.swift
@@ -31,7 +31,8 @@ internal enum APICustomHostStatus {
 	*/
 	case useDefaultVault(_ vaultURL: URL)
 
-	var url: URL? {
+	/// `URL` inferred from custom hostname status flow.
+	internal var url: URL? {
 		switch self {
 		case .isResolving:
 			return nil
@@ -41,4 +42,21 @@ internal enum APICustomHostStatus {
 			return resolvedURL
 		}
 	}
+}
+
+// MARK: - CustomStringConvertible
+
+extension APICustomHostStatus: CustomStringConvertible {
+
+	  /// Custom description.
+		var description: String {
+			switch self {
+			case .useDefaultVault(let url):
+				return ".useDefaultVault, default Vault url: \(url.absoluteString)"
+			case .resolved(let url):
+			  return ".resolved, custom host url: \(url.absoluteString)"
+			case .isResolving(let hostnameToResolve):
+				return ".isResolving hostname in progress for \(hostnameToResolve)"
+			}
+		}
 }

--- a/Sources/VGSShowSDK/Core/APIClient/APIHostName/APIHostURLPolicy.swift
+++ b/Sources/VGSShowSDK/Core/APIClient/APIHostName/APIHostURLPolicy.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 
+/// Defines API client policy for resolving URL.
 internal enum APIHostURLPolicy {
 
 	/**
@@ -28,7 +29,16 @@ internal enum APIHostURLPolicy {
 	*/
 	case invalidVaultURL
 
-	var url: URL? {
+	/**
+	 Use satellite url for local testing.
+
+	 - Parameters:
+			- url: `URL` object, should be valid satellite URL for local testing.
+	*/
+	case satelliteURL(_ satelliteURL: URL)
+
+	/// `URL?` inferred from current API policy flow.
+	internal var url: URL? {
 		switch self {
 		case .invalidVaultURL:
 			return nil
@@ -36,6 +46,27 @@ internal enum APIHostURLPolicy {
 			return vaultURL
 		case .customHostURL(let hostStatus):
 			return hostStatus.url
+		case .satelliteURL(let satelliteURL):
+			return satelliteURL
 		}
 	}
+}
+
+// MARK: - CustomStringConvertible
+
+extension APIHostURLPolicy: CustomStringConvertible {
+
+		/// Custom description.
+		var description: String {
+			switch self {
+			case .invalidVaultURL:
+				return "*.invalidVaultURL* - API url is *nil*, SDK has incorrect configuration."
+			case .vaultURL(let vaultURL):
+				return "*.vaultURL* - use regular flow, url: \(vaultURL.absoluteString)"
+			case .customHostURL(let status):
+				return "*.customHostURL* with status: \(status.description)"
+			case .satelliteURL(let satelliteURL):
+				return "*.satelliteURL* - url: \(satelliteURL.absoluteString)"
+			}
+		}
 }

--- a/Sources/VGSShowSDK/Core/APIClient/SatelliteUtils/VGSShowSatelliteUtils.swift
+++ b/Sources/VGSShowSDK/Core/APIClient/SatelliteUtils/VGSShowSatelliteUtils.swift
@@ -1,0 +1,178 @@
+//
+//  VGSShowSatelliteUtils.swift
+//  VGSShowSDK
+//
+//  Created on 22.02.2021.
+//  Copyright © 2021 VGS. All rights reserved.
+//
+
+import Foundation
+
+/// VGSShowSDK utils for satellite.
+internal class VGSShowSatelliteUtils {
+
+	/// Enable assertions on default, disable in unit tests.
+	internal static var isAssertionsEnabled = true
+
+	/// Constants.
+	internal enum Constants {
+
+		/// Valid port numbers. https://en.wikipedia.org/wiki/Port_(computer_networking)#Port_number
+		static let validPortNumbers: ClosedRange<Int> = 1...65535
+
+		/// Valid localhost prefix.
+		static let validLocalHostPrefix = "localhost"
+
+		/// Valid localhost IP address prefix.
+		static let validLocalIPAddressPrefix = "192.168"
+	}
+
+	/// Build URL for satellite.
+	/// - Parameters:
+	///   - environment: `String` object, only `sandbox` is valid.
+	///   - hostname: `String` object, should be valid hostname for satellite.
+	///   - satellitePort: `Int` object, should be valid port.
+	/// - Returns: `URL?`, satellite `URL` or `nil` for invalid configuration.
+	internal static func buildSatelliteURL(with environment: String, hostname: String?, satellitePort: Int) -> URL? {
+
+		// Check satelliteHostname is set.
+		guard let satelliteHostname = hostname else {
+			let errorText = "SATELLITE CONFIGURATION ERROR! HOSTNAME NOT SET! SHOULD BE *http://localhost* or in local IP format  http://192.168.X.X"
+			let event = VGSLogEvent(level: .warning, text: errorText, severityLevel: .error)
+			VGSLogger.shared.forwardLogEvent(event)
+
+			forwardAssertion(with: errorText)
+
+			return nil
+		}
+
+		// Check environment == .sandbox, validate port.
+		guard isEnvironmentValidForSatellite(environment), isSatellitePortValid(satellitePort) else {
+			return nil
+		}
+
+		// Check hostname is valid for satellite.
+		guard isSatelliteHostnameValid(satelliteHostname) else {
+			return nil
+		}
+
+		// Cannot build hostname URL for satellite.
+		let errorText = "SATELLITE CONFIGURATION ERROR! HOSTNAME \(satelliteHostname) IS NOT VALID AND CANNOT BE NORMALIZED FOR SATELLITE! SHOULD BE *http://localhost* or *http://192.168.*"
+		let event = VGSLogEvent(level: .warning, text: errorText, severityLevel: .error)
+
+		// Normalize hostname. 
+		guard let normalizedHostname = satelliteHostname.normalizedHostname() else {
+			forwardAssertion(with: errorText)
+			VGSLogger.shared.forwardLogEvent(event)
+			return nil
+		}
+
+		let infoText = "normalized hostname for satellite: \(normalizedHostname)"
+		let normalizeHostnameEvent = VGSLogEvent(level: .info, text: infoText)
+		VGSLogger.shared.forwardLogEvent(normalizeHostnameEvent)
+
+		guard let url = URL(string: "http://" + normalizedHostname + ":\(satellitePort)") else {
+
+			VGSLogger.shared.forwardLogEvent(event)
+
+			forwardAssertion(with: errorText)
+			return nil
+		}
+
+		return url
+	}
+
+	/// Validate satellite hostname. Should be http://localhost or http://192.168 or 192.168.1.3
+	/// Any other hostnames will be ignored for satellite.
+	/// - Parameter hostname: `String` object, hostname to validate.
+	/// - Returns: `true` if hostname is valid for satellite.
+	internal static func isSatelliteHostnameValid(_ hostname: String) -> Bool {
+
+		let errorText = "SATELLITE CONFIGURATION ERROR! HOSTNAME \(hostname) IS INVALID FOR SATELLITE! SHOULD BE *http://localhost* or *192.168.*"
+
+		// Normalize hostname. Create components to check hostname.
+		guard let normalizedHostName = hostname.normalizedHostname(), let components = URLComponents(string: normalizedHostName) else {
+			let event = VGSLogEvent(level: .warning, text: errorText, severityLevel: .error)
+			VGSLogger.shared.forwardLogEvent(event)
+
+			forwardAssertion(with: errorText)
+
+			return false
+		}
+
+		var path: String
+		if let componentHost = components.host {
+			// Use hostname if component is url with scheme.
+			path = componentHost
+		} else {
+			// Use path if component has path only.
+			path = components.path
+		}
+
+		if path == Constants.validLocalHostPrefix {
+			return true
+		}
+
+		if path.hasPrefix(Constants.validLocalIPAddressPrefix) && verifyIPHostNameIsCorrect(path) {
+			return true
+		}
+
+		let event = VGSLogEvent(level: .warning, text: errorText, severityLevel: .error)
+		VGSLogger.shared.forwardLogEvent(event)
+
+		forwardAssertion(with: errorText)
+
+		return false
+	}
+
+	/// Return `true` if environment is valid for satellite (`.sandbox`).
+	/// - Parameter environment: `String` object, environment to check.
+	/// - Returns: `Bool` flag, `true` if `.sandbox`, otherwise `false`.
+	internal static func isEnvironmentValidForSatellite(_ environment: String) -> Bool {
+		guard environment == VGSEnvironment.sandbox.rawValue else {
+			let errorText = "CONFIGURATION ERROR! ENVIRONMENT *\(environment)* IS NOT *sandbox*! SATELLITE IS AVAILABLE ONLY FOR *sandbox*!"
+			let event = VGSLogEvent(level: .warning, text: errorText, severityLevel: .error)
+			VGSLogger.shared.forwardLogEvent(event)
+
+			forwardAssertion(with: errorText)
+
+			return false
+		}
+
+		return true
+	}
+
+	/// Return `true` if port is valid for satellite.
+	/// - Parameter port: `Int` object, should be valid port.
+	/// - Returns: `Bool` flag, `true` if port in range *1...65535*, otherwise `false`.
+	internal static func isSatellitePortValid(_ port: Int) -> Bool {
+		guard Constants.validPortNumbers.contains(port) else {
+			let errorText = "SATELLITE CONFIGURATION ERROR! PORT \(port) is invalid! Should be in range *1...65535*."
+			let event = VGSLogEvent(level: .warning, text: errorText, severityLevel: .error)
+			VGSLogger.shared.forwardLogEvent(event)
+
+			forwardAssertion(with: errorText)
+
+			return false
+		}
+
+		return true
+	}
+
+	/// Forward satellite assertions.
+	/// - Parameter assertionText: `String` object, assertion message.
+	internal static func forwardAssertion(with assertionText: String) {
+		if isAssertionsEnabled {
+			assertionFailure(assertionText)
+		}
+	}
+
+	/// Verify ip-format hostname has only digits and *.*.
+	/// - Parameter hostname: `String` object to validate.
+	/// - Returns: `true` if valid ip format.
+	internal static func verifyIPHostNameIsCorrect(_ hostname: String) -> Bool {
+		let characterSet: Set<Character> = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "."]
+
+		return Set(hostname).isSubset(of: characterSet)
+	}
+}

--- a/Sources/VGSShowSDK/Core/Analytics/VGSAnalyticsClient.swift
+++ b/Sources/VGSShowSDK/Core/Analytics/VGSAnalyticsClient.swift
@@ -78,12 +78,18 @@ public class VGSAnalyticsClient {
 											 "tnt": form.tenantId,
 											 "env": env
 		]
-		let data: [String: Any]
+
+		var data: [String: Any]
 		if let extraData = extraData {
 			data = deepMerge(formDetails, extraData)
 		} else {
 			data = formDetails
 		}
+
+		if case .satelliteURL = form.apiClient.hostURLPolicy {
+			data["vgsSatellite"] = true
+		}
+
 		trackEvent(type, status: status, extraData: data)
 	}
 

--- a/Sources/VGSShowSDK/Core/Show/VGSShow.swift
+++ b/Sources/VGSShowSDK/Core/Show/VGSShow.swift
@@ -64,8 +64,9 @@ public final class VGSShow {
   ///   - id: `String` object, your organization vault id.
   ///   - environment: `String` object, your organization vault environment with data region.(e.g. "live", "live-eu1", "sanbox").
 	///   - hostname: `String` object. Custom Hostname, if not set, data will be sent to Vault Url. Default is `nil`.
-	public init(id: String, environment: String, hostname: String? = nil) {
-		self.apiClient = APIClient(tenantId: id, regionalEnvironment: environment, hostname: hostname)
+	///   - satellitePort: `Int?` object, custom port for satellite configuration.  Default is `nil`. **IMPORTANT! Use only with .sandbox environment! Hostname should be specified for valid http://localhost (for simulator) or in local IP format  http://192.168.X.X (for real device connected to the same local network as Mac)**.
+	public init(id: String, environment: String, hostname: String? = nil, satellitePort: Int? = nil) {
+		self.apiClient = APIClient(tenantId: id, regionalEnvironment: environment, hostname: hostname, satellitePort: satellitePort)
     self.tenantId = id
     self.regionalEnvironment = environment
   }
@@ -77,9 +78,10 @@ public final class VGSShow {
   ///   - environment: `VGSEnvironment` object, your organization vault environment. By default `.sandbox`.
   ///   - dataRegion: `String` object, id of data storage region (e.g. "eu-123").
 	///   - hostname: `String` object. Custom Hostname, if not set, data will be sent to Vault Url. Default is `nil`.
-	public convenience init(id: String, environment: VGSEnvironment = .sandbox, dataRegion: String? = nil, hostname: String? = nil) {
+	///   - satellitePort: `Int?` object, custom port for satellite configuration.  Default is `nil`. **IMPORTANT! Use only with .sandbox environment! Hostname should be specified for valid http://localhost (for simulator) or in local IP format  http://192.168.X.X (for real device connected to the same local network as Mac)** .
+	public convenience init(id: String, environment: VGSEnvironment = .sandbox, dataRegion: String? = nil, hostname: String? = nil, satellitePort: Int? = nil) {
     let env = Self.generateRegionalEnvironmentString(environment, region: dataRegion)
-    self.init(id: id, environment: env, hostname: hostname)
+    self.init(id: id, environment: env, hostname: hostname, satellitePort: satellitePort)
   }
   
   // MARK: - Manage Views

--- a/Sources/VGSShowSDK/Utils/Helpers/Loggers/VGSLogger.swift
+++ b/Sources/VGSShowSDK/Utils/Helpers/Loggers/VGSLogger.swift
@@ -5,7 +5,8 @@
 
 import Foundation
 
-/// `VGSLogger` encapsulates logging logic and debugging options for VGSShowSDK. Use `.configuration` property to setup these options. `VGSLogger` logging implies only printing logs to Xcode console. It doesn't save logs to persistent store/local file, also it doesn't send debugging logs to backend services.
+/// `VGSLogger` encapsulates logging logic and debugging options for VGSShowSDK. Use `.configuration` property to setup these options.
+/// `VGSLogger` logging implies only printing logs to Xcode console. It doesn't save logs to persistent store/local file, also it doesn't send debugging logs to backend services.
 /// **IMPORTANT** You should NOT use logging in your production configuration for live apps.
 public final class VGSLogger {
 

--- a/Tests/VGSShowSDKTests/Masks/VGSShowRegexMaskTests.swift
+++ b/Tests/VGSShowSDKTests/Masks/VGSShowRegexMaskTests.swift
@@ -31,16 +31,15 @@ final class VGSShowRegexMaskTests: XCTestCase {
 				let regex = try NSRegularExpression(pattern: cardNumberPattern, options: [])
 				vgsLabel.addTransformationRegex(regex, template: templates[index])
 			} catch {
-				assertionFailure("invalid regex")
+				XCTFail("invalid regex at index: \(index)")
 			}
 
-			print("label.text: \(vgsLabel.label.secureText)")
-			XCTAssert(vgsLabel.label.secureText == transformedTexts[index])
+			XCTAssert(vgsLabel.label.secureText == transformedTexts[index], "label.text: \(vgsLabel.label.secureText ?? "*nil*") should match \(transformedTexts[index])")
 		}
 
 		// Test reset to raw text.
 		vgsLabel.resetAllMasks()
-		XCTAssert(vgsLabel.label.secureText == cardNumber)
+		XCTAssert(vgsLabel.label.secureText == cardNumber, "label.text: \(vgsLabel.label.secureText ?? "*nil*") after reset should match unformatted \(cardNumber)")
 
 		// Test multiple formatters.
 		for index in 0..<templates.count {
@@ -48,7 +47,7 @@ final class VGSShowRegexMaskTests: XCTestCase {
 				let regex = try NSRegularExpression(pattern: cardNumberPattern, options: [])
 				vgsLabel.addTransformationRegex(regex, template: templates[index])
 			} catch {
-				assertionFailure("invalid regex")
+				XCTFail("invalid regex")
 			}
 		}
 

--- a/Tests/VGSShowSDKTests/Masks/VGSShowSecureTextRangesTests.swift
+++ b/Tests/VGSShowSDKTests/Masks/VGSShowSecureTextRangesTests.swift
@@ -112,7 +112,7 @@ final class VGSShowSecureTextRangesTests: XCTestCase {
 				vgsLabel.addTransformationRegex(regex, template: template)
 
 			} catch {
-				assertionFailure("invalid regex")
+				XCTFail("invalid regex")
 			}
 
 			XCTAssert(vgsLabel.label.secureText == transformedText)
@@ -127,7 +127,7 @@ final class VGSShowSecureTextRangesTests: XCTestCase {
 			print("valid masked text: \(testItem.maskedText)")
 
 			if vgsLabel.label.secureText != testItem.maskedText {
-				assertionFailure("Failed!")
+				XCTFail("Failed!")
 			}
 		}
 	}
@@ -162,7 +162,7 @@ final class VGSShowSecureTextRangesTests: XCTestCase {
 			print("valid masked text: \(testItem.maskedText)")
 
 			if vgsLabel.label.secureText != testItem.maskedText {
-				assertionFailure("Failed!")
+				XCTFail("Failed! \(vgsLabel.label.secureText ?? "*nil*") != \(testItem.maskedText)")
 			}
 		}
 	}
@@ -181,7 +181,7 @@ final class VGSShowSecureTextRangesTests: XCTestCase {
       let regex = try NSRegularExpression(pattern: cardNumberPattern, options: [])
       vgsLabel.addTransformationRegex(regex, template: template)
     } catch {
-      assertionFailure("invalid regex")
+      XCTFail("invalid regex")
     }
 
     XCTAssert(vgsLabel.label.secureText == transformedText)
@@ -216,7 +216,7 @@ final class VGSShowSecureTextRangesTests: XCTestCase {
         let textRanges = testItem.ranges
         vgsLabel.setSecureText(ranges: textRanges)
 
-        XCTAssertTrue(vgsLabel.label.secureText == testItem.espectedResult, "Failed:\n  -espectedResult: \(testItem.espectedResult)\n  -result: \(vgsLabel.label.secureText)")
+        XCTAssertTrue(vgsLabel.label.secureText == testItem.espectedResult, "Failed:\n  -espectedResult: \(testItem.espectedResult)\n  -result: \(vgsLabel.label.secureText  ?? "*nil*")")
       }
   }
   
@@ -234,7 +234,7 @@ final class VGSShowSecureTextRangesTests: XCTestCase {
       let regex = try NSRegularExpression(pattern: cardNumberPattern, options: [])
       vgsLabel.addTransformationRegex(regex, template: template)
     } catch {
-      assertionFailure("invalid regex")
+      XCTFail("invalid regex")
     }
 
     XCTAssert(vgsLabel.label.secureText == transformedText)
@@ -266,7 +266,7 @@ final class VGSShowSecureTextRangesTests: XCTestCase {
         let textRanges = testItem.ranges
         vgsLabel.setSecureText(ranges: textRanges)
         
-        XCTAssertTrue(vgsLabel.label.secureText == testItem.espectedResult, "Failed:\n  -espectedResult: \(testItem.espectedResult)\n  -result: \(vgsLabel.label.secureText)")
+        XCTAssertTrue(vgsLabel.label.secureText == testItem.espectedResult, "Failed:\n  -espectedResult: \(testItem.espectedResult)\n  -result: \(vgsLabel.label.secureText ?? "*nil*")")
       }
   }
   
@@ -300,7 +300,7 @@ final class VGSShowSecureTextRangesTests: XCTestCase {
         let textRanges = testItem.ranges
         vgsLabel.setSecureText(ranges: textRanges)
 
-        XCTAssertTrue(vgsLabel.label.secureText == testItem.espectedResult, "Failed:\n  -espectedResult: \(testItem.espectedResult)\n  -result: \(vgsLabel.label.secureText)")
+        XCTAssertTrue(vgsLabel.label.secureText == testItem.espectedResult, "Failed:\n  -espectedResult: \(testItem.espectedResult)\n  -result: \(vgsLabel.label.secureText ?? "*nil*")")
       }
     }
       

--- a/Tests/VGSShowSDKTests/VGSShowTests/APIHostnameValidatorTests.swift
+++ b/Tests/VGSShowSDKTests/VGSShowTests/APIHostnameValidatorTests.swift
@@ -29,7 +29,7 @@ class APIHostnameValidatorTests: XCTestCase {
 				print("test hostname: \(hostname)")
 				XCTAssertTrue(url == validURL)
 			} else {
-				assertionFailure("Cannot build url with hostname: \(hostname)")
+				XCTFail("Cannot build url with hostname: \(hostname)")
 			}
 		}
 	}
@@ -53,7 +53,7 @@ class APIHostnameValidatorTests: XCTestCase {
 				print("test hostname: \(hostname)")
 				XCTAssertTrue(url == validURL)
 			} else {
-				assertionFailure("Cannot build url with hostname: \(hostname)")
+				XCTFail("Cannot build url with hostname: \(hostname)")
 			}
 		}
 	}
@@ -76,7 +76,7 @@ class APIHostnameValidatorTests: XCTestCase {
 				print("test hostname: \(hostname)")
 				XCTAssertTrue(url == validURL)
 			} else {
-				assertionFailure("Cannot build url with hostname: \(hostname)")
+				XCTFail("Cannot build url with hostname: \(hostname)")
 			}
 		}
 	}
@@ -90,7 +90,7 @@ class APIHostnameValidatorTests: XCTestCase {
 		XCTAssertFalse(insecureURL.hasSecureScheme())
 
 		guard let updatedURL = URL.urlWithSecureScheme(from: insecureURL) else {
-			assertionFailure("Failed. Cannot change URL scheme from \(insecureURL)")
+			XCTFail("Failed. Cannot change URL scheme from \(insecureURL)")
 			return
 		}
 

--- a/Tests/VGSShowSDKTests/VGSShowTests/Satellite Tests/VGSShow+SatelliteTests.swift
+++ b/Tests/VGSShowSDKTests/VGSShowTests/Satellite Tests/VGSShow+SatelliteTests.swift
@@ -1,0 +1,110 @@
+//
+//  VGSShow+SatelliteTests.swift
+//  FrameworkTests
+//
+//  Created on 22.02.2021.
+//  Copyright © 2021 VGS. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import VGSShowSDK
+
+/// Test show configuration for satellite.
+class VGSShowSatelliteTests: VGSShowBaseTestCase {
+
+	/// Valid tenant ID.
+	fileprivate	let tenantID: String = "testID"
+
+	/// Holds satellite test data.
+	struct APISatelliteTestData {
+		let environment: String
+		let hostname: String?
+		let port: Int?
+		let url: URL
+	}
+
+	/// Set up satellite tests.
+	override func setUp() {
+		super.setUp()
+
+		// Disable satellite assetions for unit tests.
+		VGSShowSatelliteUtils.isAssertionsEnabled = false
+	}
+
+	/// Tear down flow.
+	override func tearDown() {
+		super.tearDown()
+
+		// Enable satellite assertions.
+		VGSShowSatelliteUtils.isAssertionsEnabled = true
+	}
+
+	/// Test show init with valid satellite configuration.
+	func testShowInitWithValidSatelliteConfiguration() {
+		let testData = [
+			APISatelliteTestData(environment: "sandbox", hostname: "localhost", port: 9908, url: URL(string: "http://localhost:9908")!),
+
+			APISatelliteTestData(environment: "sandbox", hostname: "192.168.0", port: 9908, url: URL(string: "http://192.168.0:9908")!),
+
+			APISatelliteTestData(environment: "sandbox", hostname: "192.168.1.5", port: 9908, url: URL(string: "http://192.168.1.5:9908")!),
+
+			APISatelliteTestData(environment: "sandbox", hostname: "http://192.168.1.5", port: 9908, url: URL(string: "http://192.168.1.5:9908")!)
+		]
+
+		for index in 0..<testData.count {
+			let config = testData[index]
+
+			let outputText = "index: \(index) show satellite configuration with environment: \(config.environment) hostname: \(config.hostname ?? "*nil*") port: \(config.port!) should produce satellite show: \(config.url)"
+
+			// Test init with enum.
+			let show1 = VGSShow(id: tenantID, environment: .sandbox, hostname: config.hostname, satellitePort: config.port)
+
+			let url1 = show1.apiClient.baseURL?.absoluteString ?? ""
+			XCTAssertTrue(url1 == config.url.absoluteString, "\(outputText) - enum init produced: \(url1) should match \(config.url.absoluteString)")
+
+			// Test init with String environment.
+			let show2 = VGSShow(id: tenantID, environment: config.environment, hostname: config.hostname, satellitePort: config.port)
+
+			let url2 = show2.apiClient.baseURL?.absoluteString ?? ""
+			XCTAssertTrue(url2 == config.url.absoluteString, "\(outputText) - string init produced: \(url2) should match \(config.url.absoluteString)")
+		}
+	}
+
+	/// Test show init with invalid satellite configuration.
+	func testShowInitWithInvalidSatelliteConfiguration() {
+		let testData = [
+			APISatelliteTestData(environment: "live", hostname: "localhost", port: 9908, url: URL(string: "https://testID.live.verygoodproxy.com")!),
+
+			APISatelliteTestData(environment: "live", hostname: "192.168.0", port: 9908, url: URL(string: "https://testID.live.verygoodproxy.com")!),
+
+			APISatelliteTestData(environment: "live", hostname: nil, port: 9908, url: URL(string: "https://testID.live.verygoodproxy.com")!),
+
+			APISatelliteTestData(environment: "live", hostname: nil, port: nil, url: URL(string: "https://testID.live.verygoodproxy.com")!),
+
+			APISatelliteTestData(environment: "live", hostname: "http://192.168.1.5", port: 9908, url: URL(string: "https://testID.live.verygoodproxy.com")!)
+		]
+
+		for index in 0..<testData.count {
+			let config = testData[index]
+			var portText = "nil"
+			if let port = config.port {
+				portText = "\(port)"
+			}
+
+			let outputText = "index: \(index) show satellite INVALID configuration with environment: \(config.environment) hostname: \(config.hostname ?? "*nil*") port: \(portText) should produce normal vault show URL: \(config.url)"
+
+			// Test init with enum.
+			let show1 = VGSShow(id: tenantID, environment: .live, hostname: config.hostname, satellitePort: config.port)
+
+			let url1 = show1.apiClient.baseURL?.absoluteString ?? ""
+			XCTAssertTrue(url1 == config.url.absoluteString, "\(outputText) - produced: \(url1) should match normal vault URL \(config.url.absoluteString)")
+
+			// Test init with String environment.
+			let show2 = VGSShow(id: tenantID, environment: config.environment, hostname: config.hostname, satellitePort: config.port)
+
+			let url2 = show2.apiClient.baseURL?.absoluteString ?? ""
+			XCTAssertTrue(url2 == config.url.absoluteString, "\(outputText) - produced: \(url2) should match normal vault URL \(config.url.absoluteString)")
+		}
+	}
+}

--- a/Tests/VGSShowSDKTests/VGSShowTests/Satellite Tests/VGSShowAPIClientSatelliteTests.swift
+++ b/Tests/VGSShowSDKTests/VGSShowTests/Satellite Tests/VGSShowAPIClientSatelliteTests.swift
@@ -1,0 +1,110 @@
+//
+//  VGSShowAPIClientSatelliteTests.swift
+//  FrameworkTests
+//
+//  Created on 22.02.2021.
+//  Copyright © 2021 VGS. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import VGSShowSDK
+
+/// Tests for API cleint and satellite configuration: verify API URL policy setup.
+class VGSShowAPIClientSatelliteTests: VGSShowBaseTestCase {
+
+	/// Valid tenant ID.
+	let tenantID: String = "testID"
+
+	/// Holds satellite test data.
+	struct APISatelliteTestData {
+	 let environment: String
+	 let hostname: String?
+	 let port: Int?
+	 let url: URL
+	}
+
+	/// Set up satellite tests.
+	override func setUp() {
+		super.setUp()
+
+		// Disable satellite assetions for unit tests.
+		VGSShowSatelliteUtils.isAssertionsEnabled = false
+	}
+
+	/// Tear down flow.
+	override func tearDown() {
+		super.tearDown()
+
+		// Enable satellite assertions.
+		VGSShowSatelliteUtils.isAssertionsEnabled = true
+	}
+
+	/// Test `API` valid satellite configurations to be resolved to `.satelliteURL` policy.
+	func testAPIURLPolicyValidSatellite() {
+		let testData = [
+			APISatelliteTestData(environment: "sandbox", hostname: "localhost", port: 9908, url: URL(string: "http://localhost:9908")!),
+
+			APISatelliteTestData(environment: "sandbox", hostname: "192.168.0", port: 9908, url: URL(string: "http://192.168.0:9908")!),
+
+			APISatelliteTestData(environment: "sandbox", hostname: "192.168.1.5", port: 9908, url: URL(string: "http://192.168.1.5:9908")!),
+
+			APISatelliteTestData(environment: "sandbox", hostname: "http://192.168.1.5", port: 9908, url: URL(string: "http://192.168.1.5:9908")!)
+		]
+
+		for index in 0..<testData.count {
+			let config = testData[index]
+
+			let outputText = "index: \(index) satellite configuration with environment: \(config.environment) hostname: \(config.hostname ?? "*nil*") port: \(config.port!) should produce: \(config.url)"
+			let client = APIClient(tenantId: tenantID, regionalEnvironment: config.environment, hostname: config.hostname, satellitePort: config.port)
+
+			switch client.hostURLPolicy {
+			case .satelliteURL(let url):
+				XCTAssertTrue(url == config.url, outputText)
+			case .invalidVaultURL:
+				XCTFail("\(outputText). API policy is *invalidURL*. Should be *satelliteURL* policy!!!")
+			case .customHostURL:
+				XCTFail("\(outputText). API policy is *customHostURL*. Should be *satelliteURL* policy URL mode!!!")
+			case .vaultURL:
+				XCTFail("\(outputText). API policy is *vaultURL*. Should be *satelliteURL* policy URL mode!!!")
+			}
+		}
+	}
+
+	/// Test `API` invalid satellite configurations to be resolved to `.vaultURL` policy.
+	func testAPIURLPolicyInValidSatellite() {
+		let testData = [
+			APISatelliteTestData(environment: "live", hostname: "localhost", port: 9908, url: URL(string: "https://testID.live.verygoodproxy.com")!),
+
+			APISatelliteTestData(environment: "live-eu", hostname: "192.168.0", port: 9908, url: URL(string: "https://testID.live-eu.verygoodproxy.com")!),
+
+			APISatelliteTestData(environment: "sandbox", hostname: nil, port: 9908, url: URL(string: "https://testID.sandbox.verygoodproxy.com")!),
+
+			APISatelliteTestData(environment: "sandbox", hostname: nil, port: nil, url: URL(string: "https://testID.sandbox.verygoodproxy.com")!),
+
+			APISatelliteTestData(environment: "live", hostname: "http://192.168.1.5", port: 9908, url: URL(string: "https://testID.live.verygoodproxy.com")!)
+		]
+
+		for index in 0..<testData.count {
+			let config = testData[index]
+			var portText = "nil"
+			if let port = config.port {
+				portText = "\(port)"
+			}
+
+			let outputText = "index: \(index) satellite configuration with environment: \(config.environment) hostname: \(config.hostname ?? "*nil*") port: \(portText) should produce *nil*"
+			let client = APIClient(tenantId: tenantID, regionalEnvironment: config.environment, hostname: config.hostname, satellitePort: config.port)
+
+			switch client.hostURLPolicy {
+			case .vaultURL(let url):
+				XCTAssertTrue(url == config.url, "outputText \(url.absoluteString) should match normal vault URL: \(config.url.absoluteString))")
+			case .satelliteURL:
+				XCTFail("\(outputText). API policy is *satellite*. Should be *vaultURL* policy!!!")
+			case .invalidVaultURL:
+				XCTFail("\(outputText). API policy is *invalidURL*. Should be *vaultURL* policy!!!")
+			case .customHostURL:
+				XCTFail("\(outputText). API policy is *customHostURL*. Should be *vaultURL* policy URL mode!!!")
+			}
+		}
+	}
+}

--- a/Tests/VGSShowSDKTests/VGSShowTests/Satellite Tests/VGSShowSatelliteUtilsTests.swift
+++ b/Tests/VGSShowSDKTests/VGSShowTests/Satellite Tests/VGSShowSatelliteUtilsTests.swift
@@ -1,0 +1,242 @@
+//
+//  VGSShowSatelliteUtilsTests.swift
+//  FrameworkTests
+//
+//  Created on 22.02.2021.
+//  Copyright © 2021 VGS. All rights reserved.
+//
+
+import XCTest
+@testable import VGSShowSDK
+
+/// Test satellite utils: local hostname and port validation, building satellite URL with valid/invalid configurations.
+class VGSShowSatelliteUtilsTests: VGSShowBaseTestCase {
+
+	/// Holds satellite test data.
+	struct SatelliteTestData {
+	 let hostname: String
+	 let port: Int
+	 let satelliteURL: URL?
+	}
+
+	/// Set up satellite tests.
+	override func setUp() {
+		super.setUp()
+
+		// Disable satellite assetions for unit tests.
+		VGSShowSatelliteUtils.isAssertionsEnabled = false
+	}
+
+	/// Tear down flow.
+	override func tearDown() {
+		super.tearDown()
+
+		// Enable satellite assertions.
+		VGSShowSatelliteUtils.isAssertionsEnabled = true
+	}
+
+	/// Test satellite hostname normalization with IP address.
+	func testNormalizeSatelliteHostnameForIPAddress() {
+		let validNormalizedIPHostname = "192.168.1.5"
+
+		let ipHostnames = ["192.168.1.5", "http://192.168.1.5", "http:192.168.1.5"]
+
+		for index in 0..<ipHostnames.count {
+			if let normalized = ipHostnames[index].normalizedHostname() {
+				XCTAssert(normalized == validNormalizedIPHostname)
+			} else {
+				XCTFail("cannot normalize: \(ipHostnames[index])")
+			}
+		}
+	}
+
+	/// Test satellite hostname normalization with localhost.
+	func testNormalizeForLocalHost() {
+		let validNormalizedHostname = "localhost"
+		let hostnames = ["localhost", "http://localhost", "http:localhost", "http://localhost/database/users?id=1"]
+
+		for index in 0..<hostnames.count {
+			if let normalized = hostnames[index].normalizedHostname() {
+				XCTAssert(normalized == validNormalizedHostname)
+			} else {
+				XCTFail("cannot normalize: \(hostnames[index])")
+			}
+		}
+	}
+
+	/// Test port validation.
+	func testPortValidation() {
+		let validPorts = [1, 2, 3, 88, 9098, 80, 1000]
+		let invalidPorts = [-1, 0, 100000000, 1000000000]
+
+		for index in 0..<validPorts.count {
+			XCTAssertTrue(VGSShowSatelliteUtils.isSatellitePortValid(validPorts[index]), "*\(validPorts[index]) is valid port.*")
+		}
+
+		for index in 0..<invalidPorts.count {
+			XCTAssertFalse(VGSShowSatelliteUtils.isSatellitePortValid(invalidPorts[index]), "*\(invalidPorts[index]) is invalid port.*")
+		}
+	}
+
+	/// Test satellite hostname validation.
+	func testSatelliteValidHostnames() {
+		let validhostnames = ["localhost", "http://localhost", "http:localhost", "192.168.1", "192.168.1.3", "192.168.1.5", "http://192.168.1.3"]
+
+		for index in 0..<validhostnames.count {
+			XCTAssertTrue(VGSShowSatelliteUtils.isSatelliteHostnameValid(validhostnames[index]), "*\(validhostnames[index]) is valid hostname.*")
+		}
+	}
+
+	/// Test invalid hostnames.
+	func testSatelliteInvalidHostnames() {
+		let invalidhostnames = ["google", "http://google.com", "http://localhostsomebackend", "193.168.1", "192.169.1.3", "192.170.1.5", "http://190.168.1.3"]
+
+		for index in 0..<invalidhostnames.count {
+			XCTAssertFalse(VGSShowSatelliteUtils.isSatelliteHostnameValid(invalidhostnames[index]), "*\(invalidhostnames[index]) is invalid hostname.*")
+		}
+	}
+
+	/// Test build satelite URL function.
+	func testBuildSatelliteURL() {
+
+		let testData: [SatelliteTestData] = [
+			SatelliteTestData(hostname: "localhost", port: 9098, satelliteURL: URL(string: "http://localhost:9098")!),
+
+			SatelliteTestData(hostname: "http://localhost", port: 9098, satelliteURL: URL(string: "http://localhost:9098")!),
+
+			// Hostname *localhost/backend* will be nornalized to *localhost* only.
+			SatelliteTestData(hostname: "http://localhost/backend", port: 9098, satelliteURL: URL(string: "http://localhost:9098")!),
+
+			// Hostname  *localhost:* will be normalized to *localhost* only.
+			SatelliteTestData(hostname: "http://localhost:", port: 9098, satelliteURL: URL(string: "http://localhost:9098")!),
+
+			SatelliteTestData(hostname: "192.168.0", port: 9098, satelliteURL: URL(string: "http://192.168.0:9098")!),
+
+			SatelliteTestData(hostname: "192.168.1", port: 9098, satelliteURL: URL(string: "http://192.168.1:9098")!),
+
+			SatelliteTestData(hostname: "192.168.1.5", port: 9098, satelliteURL: URL(string: "http://192.168.1.5:9098")!),
+
+			SatelliteTestData(hostname: "http://192.168.0", port: 9098, satelliteURL: URL(string: "http://192.168.0:9098")!),
+
+			SatelliteTestData(hostname: "http://192.168.1", port: 9098, satelliteURL: URL(string: "http://192.168.1:9098")!),
+
+			SatelliteTestData(hostname: "http://192.168.1.5", port: 9098, satelliteURL: URL(string: "http://192.168.1.5:9098")!),
+
+			SatelliteTestData(hostname: "http:192.168.1.5", port: 9098, satelliteURL: URL(string: "http://192.168.1.5:9098")!)
+		]
+
+		for index in 0..<testData.count {
+			let config = testData[index]
+			let outputText = "index: \(index) satellite configuration with hostname: \(config.hostname) port: \(config.port) should produce: \(config.satelliteURL!)"
+			if let url = VGSShowSatelliteUtils.buildSatelliteURL(with: "sandbox", hostname: config.hostname, satellitePort: config.port) {
+				XCTAssertTrue(url == config.satelliteURL!, "error: \(url) != \(config.satelliteURL!) - " + outputText)
+			} else {
+				XCTFail(outputText)
+			}
+		}
+	}
+
+	/// Test invalid configurations: wrong hostname or port name.
+	func testInvalidSatelliteConfiguration() {
+
+		let testData: [SatelliteTestData] = [
+			SatelliteTestData(hostname: "ftp://test-ios", port: 80, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "https://test-ios", port: 9908, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "devapiclient", port: 9908, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "ftp://test-ios", port: 9908, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "localhost", port: -5, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "http://localhostbackend", port: 9098, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "http://localhost-apiclient", port: 9098, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "🐒-data", port: 80, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "", port: 9098, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "192.168.0", port: 0, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "192.168.0", port: 999999999, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "193.168.1", port: 9098, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "192.168.1.5-backend", port: 9098, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "http://193.168.0", port: 9098, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "http://192.167.1", port: 9098, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "http://188.168.1", port: 9098, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "http://199.168.1", port: 9098, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "http://localhost192.168.1.5", port: 9098, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "http://localhost:192.168.1.5", port: 9098, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "custombackend", port: 9098, satelliteURL: nil),
+
+			SatelliteTestData(hostname: "custombackend", port: 0, satelliteURL: nil)
+		]
+
+		for index in 0..<testData.count {
+			let config = testData[index]
+			let invalidURL = VGSShowSatelliteUtils.buildSatelliteURL(with: "sandbox", hostname: config.hostname, satellitePort: config.port)
+			let outputText = "index: \(index) satellite invalid configuration with hostname: \(config.hostname) port: \(config.port) should produce *nil*, actuallResult: \(invalidURL?.absoluteString ?? "*nil*")"
+			XCTAssertTrue(invalidURL == nil, outputText)
+		}
+	}
+
+	/// Test satellite ignores all non-sandbox environments.
+	func testSatelliteEnvironment() {
+		let configuration = SatelliteTestData(hostname: "localhost", port: 9098, satelliteURL: URL(string: "http://localhost:9098")!)
+
+		let testData = [
+			"live",
+			"live-eu",
+			"eu-123",
+			"us-777"
+		]
+
+		for index in 0..<testData.count {
+			let environment = testData[index]
+			let outputText = "index: \(index) satellite invalid environment: \(environment) but valid hostname: \(configuration.hostname) port: \(configuration.port) should produce *nil*"
+			let invalidURL = VGSShowSatelliteUtils.buildSatelliteURL(with: environment, hostname: configuration.hostname, satellitePort: configuration.port)
+			XCTAssertTrue(invalidURL == nil, outputText)
+		}
+	}
+
+	/// Test satellite IP has correct format.
+	func testSatelliteIPCorrectFormat() {
+
+		let validTestIPs = [
+			"192.168.1",
+			"192.168.1.3",
+			"192.168.1.5",
+			"192.168.0"
+		]
+
+		for index in 0..<validTestIPs.count {
+			let ip = validTestIPs[index]
+			let outputText = "index: \(index) satellite ip: \(ip) should be valid"
+			XCTAssertTrue(VGSShowSatelliteUtils.verifyIPHostNameIsCorrect(ip), outputText)
+		}
+
+		let invalidTestIPs = [
+			"192.168.1-localhost",
+			"192.168.1.3.backend",
+			"192.168.1.5&&&",
+			"192.168.0?="
+		]
+
+		for index in 0..<invalidTestIPs.count {
+			let ip = invalidTestIPs[index]
+			let outputText = "index: \(index) satellite ip: \(ip) should be invalid"
+			XCTAssertFalse(VGSShowSatelliteUtils.verifyIPHostNameIsCorrect(ip), outputText)
+		}
+	}
+}

--- a/Tests/VGSShowSDKTests/VGSShowTests/VGSShowBaseTestCase.swift
+++ b/Tests/VGSShowSDKTests/VGSShowTests/VGSShowBaseTestCase.swift
@@ -1,0 +1,22 @@
+//
+//  VGSShowBaseTestCase.swift
+//  VGSShowSDKTests
+//
+//  Created on 22.02.2021.
+//
+
+import Foundation
+import XCTest
+@testable import VGSShowSDK
+
+/// Base VGSShow test case for common setup.
+class VGSShowBaseTestCase: XCTestCase {
+
+	/// Setup collect before tests.
+	override func setUp() {
+		super.setUp()
+
+		// Disable analytics in unit tests.
+		VGSAnalyticsClient.shared.shouldCollectAnalytics = false
+	}
+}

--- a/Tests/VGSShowSDKTests/VGSShowTests/VGSShowTests.swift
+++ b/Tests/VGSShowSDKTests/VGSShowTests/VGSShowTests.swift
@@ -8,14 +8,18 @@
 import XCTest
 @testable import VGSShowSDK
 
-class VGSShowTests: XCTestCase {
+class VGSShowTests: VGSShowBaseTestCase {
     var vgsShow: VGSShow!
     
     override func setUp() {
+			super.setUp()
+
       vgsShow = VGSShow(id: "test")
     }
 
     override func tearDown() {
+			super.tearDown()
+
       vgsShow = nil
     }
 

--- a/VGSShowDemoApp/VGSShowDemoApp/Application/AppDelegate.swift
+++ b/VGSShowDemoApp/VGSShowDemoApp/Application/AppDelegate.swift
@@ -6,14 +6,47 @@
 //
 
 import UIKit
+import VGSShowSDK
+import VGSCollectSDK
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
 	var window: UIWindow?
 
+	/// App delegate initializer.
+	override init() {
+		super.init()
+
+		// *Setup loggers in AppDelegate -init as the earliest app stage.
+
+		// Enable loggers only for debug!
+		#if DEBUG
+		// Setup VGS Show loggers:
+		// Show warnings and errors.
+		VGSLogger.shared.configuration.level = .info
+
+		// Show network session for reveal requests.
+		VGSLogger.shared.configuration.isNetworkDebugEnabled = true
+
+		// *You can stop all VGS Show loggers in app:
+		// VGSLogger.shared.disableAllLoggers()
+
+		// Setup VGS Collect loggers:
+		// Show warnings and errors.
+		VGSCollectLogger.shared.configuration.level = .info
+
+		// Show network session for collect requests.
+		VGSCollectLogger.shared.configuration.isNetworkDebugEnabled = true
+
+		// *You can stop all VGS Collect loggers in app:
+		// VGSCollectLogger.shared.disableAllLoggers()
+		#endif
+	}
+
 	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 		// Override point for customization after application launch.
+
 		return true
 	}
 }

--- a/VGSShowDemoApp/VGSShowDemoApp/Controllers/CollectViewController.swift
+++ b/VGSShowDemoApp/VGSShowDemoApp/Controllers/CollectViewController.swift
@@ -70,7 +70,7 @@ class CollectViewController: UIViewController {
     let cardHolderNameConfiguration = VGSConfiguration(collector: vgsCollect, fieldName: "cardHolderName")
     cardHolderNameConfiguration.type = .cardHolderName
     cardHolderNameConfiguration.isRequiredValidOnly = false
-    cardHolderNameConfiguration.keyboardType = .asciiCapableNumberPad
+    cardHolderNameConfiguration.keyboardType = .asciiCapable
     cardHolderName.configuration = cardHolderNameConfiguration
     cardHolderName.placeholder = "Joe Business"
     cardHolderName.textAlignment = .natural

--- a/VGSShowDemoApp/VGSShowDemoApp/Controllers/ShowDemoViewController.swift
+++ b/VGSShowDemoApp/VGSShowDemoApp/Controllers/ShowDemoViewController.swift
@@ -89,15 +89,6 @@ class ShowDemoViewController: UIViewController {
 
 		let placeholderColor = UIColor.white.withAlphaComponent(0.7)
 
-		// Log only warnings and errors.
-		VGSLogger.shared.configuration.level = .warning
-
-		// Log network requests.
-		VGSLogger.shared.configuration.isNetworkDebugEnabled = true
-
-		// *You can stop all loggers in app:
-		// VGSLogger.shared.disableAllLoggers()
-
     // Secure revealed data with mask in ranges
     cardNumberLabel.isSecureText = true
     cardNumberLabel.setSecureText(ranges: [VGSTextRange(start: 5, end: 8),

--- a/VGSShowDemoApp/VGSShowDemoApp/Helpers/UIViewController+Extensions.swift
+++ b/VGSShowDemoApp/VGSShowDemoApp/Helpers/UIViewController+Extensions.swift
@@ -9,6 +9,7 @@ import Foundation
 import UIKit
 
 extension UIViewController {
+	// swiftlint:disable
 	static func show(message: String, controller: UIViewController) {
 		let toastView = UIView(frame: .zero)
 		toastView.backgroundColor = UIColor.black.withAlphaComponent(0.7)

--- a/VGSShowDemoApp/VGSShowDemoApp/Info.plist
+++ b/VGSShowDemoApp/VGSShowDemoApp/Info.plist
@@ -22,6 +22,11 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/VGSShowDemoApp/VGSShowDemoApp/Storyboards/Main.storyboard
+++ b/VGSShowDemoApp/VGSShowDemoApp/Storyboards/Main.storyboard
@@ -129,7 +129,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="syh-5q-JME">
-                                <rect key="frame" x="30" y="170" width="354" height="229"/>
+                                <rect key="frame" x="30" y="145" width="354" height="229"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="FeV-F5-4Dp">
                                         <rect key="frame" x="25" y="99.5" width="314" height="114.5"/>
@@ -198,10 +198,14 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="s5d-5E-TfU">
-                                <rect key="frame" x="122" y="449" width="170" height="50"/>
+                                <rect key="frame" x="332" y="45" width="52" height="40"/>
                                 <color key="backgroundColor" red="0.27216926219999998" green="0.34727090599999999" blue="0.41961821910000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="40" id="EuH-5a-kio"/>
+                                </constraints>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <state key="normal" title="Copy Card Number">
+                                <inset key="contentEdgeInsets" minX="8" minY="0.0" maxX="8" maxY="0.0"/>
+                                <state key="normal" title="Copy">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </state>
                                 <userDefinedRuntimeAttributes>
@@ -217,30 +221,22 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="s5d-5E-TfU" firstAttribute="width" secondItem="tvs-Vg-7bc" secondAttribute="width" id="0oo-K8-b8l"/>
+                            <constraint firstItem="s5d-5E-TfU" firstAttribute="trailing" secondItem="syh-5q-JME" secondAttribute="trailing" id="0aL-dx-7ga"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="wm9-aW-GUZ" secondAttribute="trailing" constant="20" id="5vf-KA-RRr"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="tvs-Vg-7bc" secondAttribute="bottom" constant="20" id="GG8-hB-YAm"/>
                             <constraint firstItem="syh-5q-JME" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="Gq4-Fi-OxA"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="5ds-QC-Jhm" secondAttribute="trailing" constant="20" id="HtA-52-z4S"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="hJE-1q-Fl5" secondAttribute="trailing" constant="20" id="HvI-KU-R6R"/>
-                            <constraint firstItem="s5d-5E-TfU" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="LWa-PU-5xW"/>
                             <constraint firstItem="wm9-aW-GUZ" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="PIk-AS-hQC"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="syh-5q-JME" secondAttribute="trailing" constant="30" id="UYI-sO-6PS"/>
-                            <constraint firstItem="s5d-5E-TfU" firstAttribute="top" secondItem="syh-5q-JME" secondAttribute="bottom" constant="50" id="WHS-uE-ywz"/>
                             <constraint firstItem="5ds-QC-Jhm" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="45" id="fLF-45-5UG"/>
                             <constraint firstItem="wm9-aW-GUZ" firstAttribute="top" secondItem="hJE-1q-Fl5" secondAttribute="bottom" constant="20" id="gXH-f5-wwW"/>
+                            <constraint firstItem="s5d-5E-TfU" firstAttribute="bottom" secondItem="5ds-QC-Jhm" secondAttribute="top" constant="-4" id="hXX-uS-7Wq"/>
                             <constraint firstItem="tvs-Vg-7bc" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="heQ-T6-J5h"/>
                             <constraint firstItem="hJE-1q-Fl5" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="hvX-UE-pxg"/>
                             <constraint firstItem="tvs-Vg-7bc" firstAttribute="top" secondItem="wm9-aW-GUZ" secondAttribute="bottom" constant="20" id="izE-xM-9l7"/>
                             <constraint firstItem="5ds-QC-Jhm" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="mM2-U8-x9g"/>
-                            <constraint firstItem="s5d-5E-TfU" firstAttribute="height" secondItem="tvs-Vg-7bc" secondAttribute="height" id="oIC-0m-lQ3">
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                        <integer key="value" value="6"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                            </constraint>
-                            <constraint firstItem="syh-5q-JME" firstAttribute="top" secondItem="5ds-QC-Jhm" secondAttribute="bottom" constant="40" id="rAy-zb-bet"/>
+                            <constraint firstItem="syh-5q-JME" firstAttribute="top" secondItem="5ds-QC-Jhm" secondAttribute="bottom" constant="15" id="rAy-zb-bet"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Show" id="c5N-b5-Mzy"/>

--- a/VGSShowSDK.xcodeproj/project.pbxproj
+++ b/VGSShowSDK.xcodeproj/project.pbxproj
@@ -13,6 +13,11 @@
 		441963C12590C36100CAFBB3 /* VGSPlaceholderLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441963C02590C36100CAFBB3 /* VGSPlaceholderLabel.swift */; };
 		441963E12592357400CAFBB3 /* VGSPlaceholderLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441963E02592357400CAFBB3 /* VGSPlaceholderLabelStyle.swift */; };
 		442F806125A5A80000CC04A2 /* VGSTextRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442F806025A5A80000CC04A2 /* VGSTextRangeTests.swift */; };
+		445FD81625E37F4000B36614 /* VGSShowSatelliteUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445FD81525E37F4000B36614 /* VGSShowSatelliteUtils.swift */; };
+		445FD81F25E38D8300B36614 /* VGSShowAPIClientSatelliteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445FD81C25E38D8300B36614 /* VGSShowAPIClientSatelliteTests.swift */; };
+		445FD82025E38D8300B36614 /* VGSShow+SatelliteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445FD81D25E38D8300B36614 /* VGSShow+SatelliteTests.swift */; };
+		445FD82125E38D8300B36614 /* VGSShowSatelliteUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445FD81E25E38D8300B36614 /* VGSShowSatelliteUtilsTests.swift */; };
+		445FD82525E38EB200B36614 /* VGSShowBaseTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445FD82425E38EB200B36614 /* VGSShowBaseTestCase.swift */; };
 		4461083225639CDF006479FB /* VGSAnalyticsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4461083125639CDF006479FB /* VGSAnalyticsClient.swift */; };
 		4461083525639DEE006479FB /* VGSUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4461083425639DEE006479FB /* VGSUtils.swift */; };
 		4479E7822567A9720056350F /* VGSShow+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4479E7812567A9720056350F /* VGSShow+Analytics.swift */; };
@@ -94,6 +99,11 @@
 		441963C02590C36100CAFBB3 /* VGSPlaceholderLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSPlaceholderLabel.swift; sourceTree = "<group>"; };
 		441963E02592357400CAFBB3 /* VGSPlaceholderLabelStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSPlaceholderLabelStyle.swift; sourceTree = "<group>"; };
 		442F806025A5A80000CC04A2 /* VGSTextRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSTextRangeTests.swift; sourceTree = "<group>"; };
+		445FD81525E37F4000B36614 /* VGSShowSatelliteUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VGSShowSatelliteUtils.swift; sourceTree = "<group>"; };
+		445FD81C25E38D8300B36614 /* VGSShowAPIClientSatelliteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VGSShowAPIClientSatelliteTests.swift; sourceTree = "<group>"; };
+		445FD81D25E38D8300B36614 /* VGSShow+SatelliteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VGSShow+SatelliteTests.swift"; sourceTree = "<group>"; };
+		445FD81E25E38D8300B36614 /* VGSShowSatelliteUtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VGSShowSatelliteUtilsTests.swift; sourceTree = "<group>"; };
+		445FD82425E38EB200B36614 /* VGSShowBaseTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSShowBaseTestCase.swift; sourceTree = "<group>"; };
 		4461083125639CDF006479FB /* VGSAnalyticsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSAnalyticsClient.swift; sourceTree = "<group>"; };
 		4461083425639DEE006479FB /* VGSUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSUtils.swift; sourceTree = "<group>"; };
 		4479E7812567A9720056350F /* VGSShow+Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VGSShow+Analytics.swift"; sourceTree = "<group>"; };
@@ -194,6 +204,24 @@
 				3211D9702542E2B4009BB381 /* VGSShowSDKTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		445FD81425E37F4000B36614 /* SatelliteUtils */ = {
+			isa = PBXGroup;
+			children = (
+				445FD81525E37F4000B36614 /* VGSShowSatelliteUtils.swift */,
+			);
+			path = SatelliteUtils;
+			sourceTree = "<group>";
+		};
+		445FD81B25E38D8300B36614 /* Satellite Tests */ = {
+			isa = PBXGroup;
+			children = (
+				445FD81C25E38D8300B36614 /* VGSShowAPIClientSatelliteTests.swift */,
+				445FD81D25E38D8300B36614 /* VGSShow+SatelliteTests.swift */,
+				445FD81E25E38D8300B36614 /* VGSShowSatelliteUtilsTests.swift */,
+			);
+			path = "Satellite Tests";
 			sourceTree = "<group>";
 		};
 		4461083025639CBB006479FB /* Analytics */ = {
@@ -318,6 +346,7 @@
 		44A79F42255D0678009AF720 /* APIClient */ = {
 			isa = PBXGroup;
 			children = (
+				445FD81425E37F4000B36614 /* SatelliteUtils */,
 				448F5625258742270024E814 /* APIHostName */,
 				44A79F43255D0678009AF720 /* APIClient.swift */,
 				448F55C9258336BA0024E814 /* VGSRequestBodyPayload.swift */,
@@ -472,9 +501,11 @@
 		44A79FB5255D06C6009AF720 /* VGSShowTests */ = {
 			isa = PBXGroup;
 			children = (
+				445FD81B25E38D8300B36614 /* Satellite Tests */,
 				44A79FB6255D06C6009AF720 /* VGSShowTests.swift */,
 				448F564325879F640024E814 /* APIHostnameValidatorTests.swift */,
 				44A79FB7255D06C6009AF720 /* VGSShowTest+Subscribe.swift */,
+				445FD82425E38EB200B36614 /* VGSShowBaseTestCase.swift */,
 			);
 			path = VGSShowTests;
 			sourceTree = "<group>";
@@ -727,6 +758,7 @@
 				448F5627258742460024E814 /* APICustomHostStatus.swift in Sources */,
 				441963C12590C36100CAFBB3 /* VGSPlaceholderLabel.swift in Sources */,
 				448B53A4256FEBF3006D730F /* VGSTextFormattersCoordinator.swift in Sources */,
+				445FD81625E37F4000B36614 /* VGSShowSatelliteUtils.swift in Sources */,
 				44BAD6DC25C289460060A170 /* VGSLogEvent.swift in Sources */,
 				44BAD76425C445A70060A170 /* VGSShow+Logging.swift in Sources */,
 				448525C525829F8400721F73 /* VGSShowRequestLogger.swift in Sources */,
@@ -746,14 +778,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				445FD82125E38D8300B36614 /* VGSShowSatelliteUtilsTests.swift in Sources */,
 				44CC283825A48FA4009B1480 /* VGSShowSecureTextRangesTests.swift in Sources */,
+				445FD82525E38EB200B36614 /* VGSShowBaseTestCase.swift in Sources */,
 				44A79FC6255D06C6009AF720 /* VGSShowTest+Subscribe.swift in Sources */,
 				44A79FC5255D06C6009AF720 /* VGSShowTests.swift in Sources */,
 				442F806125A5A80000CC04A2 /* VGSTextRangeTests.swift in Sources */,
 				44A79FC3255D06C6009AF720 /* VGSShowNestedDictionaryTests.swift in Sources */,
 				44A79FC7255D06C6009AF720 /* VGSJSONData+Bundle.swift in Sources */,
 				448F564425879F640024E814 /* APIHostnameValidatorTests.swift in Sources */,
+				445FD81F25E38D8300B36614 /* VGSShowAPIClientSatelliteTests.swift in Sources */,
 				44A79FC4255D06C6009AF720 /* VGSJSONContentPathsTests.swift in Sources */,
+				445FD82025E38D8300B36614 /* VGSShow+SatelliteTests.swift in Sources */,
 				44A79FCA255D06C6009AF720 /* VGSLabelTest.swift in Sources */,
 				44A79FC9255D06C6009AF720 /* VGSShowRegexMaskTests.swift in Sources */,
 			);


### PR DESCRIPTION
## Add Satellite integration [iOSSDK-161]

## Description of changes
-  Add Satellite integration for VGSShowSDK.
-  Refactor Unit tests (replace assertions with XCTFail, improve debug output in tests).
-  Disable Analytics in Unit tests.
-  Add -info level log event for `APIURLPolicy`.
-  Add Satellite option to analytics.
-  Update demo app (setup log level in App Delegate -init) 