### PR TITLE
Fix retain cycle in APIClient

### DIFF
--- a/Sources/VGSShowSDK/Core/APIClient/APIClient.swift
+++ b/Sources/VGSShowSDK/Core/APIClient/APIClient.swift
@@ -260,21 +260,22 @@ internal class APIClient {
 
 	private func updateHost(with hostname: String, completion: ((URL) -> Void)? = nil) {
 
-		dataSyncQueue.async {
+		dataSyncQueue.async {[weak self] in
+			guard let strongSelf = self else {return}
 
 			// Enter sync zone.
-			self.syncSemaphore.wait()
+			strongSelf.syncSemaphore.wait()
 
 			// Check if we already have URL. If yes, don't fetch it the same time.
-			if let url = self.hostURLPolicy.url {
+			if let url = strongSelf.hostURLPolicy.url {
 				completion?(url)
 				// Exit sync zone.
-				self.syncSemaphore.signal()
+				strongSelf.syncSemaphore.signal()
 				return
 			}
 
 			// Resolve hostname.
-			APIHostnameValidator.validateCustomHostname(hostname, tenantId: self.vaultId) {[weak self](url) in
+			APIHostnameValidator.validateCustomHostname(hostname, tenantId: strongSelf.vaultId) {[weak self](url) in
 				if var validUrl = url {
 
 					// Update url scheme if needed.


### PR DESCRIPTION
## Fixes [iOSSDK-XXXX]

## Description of changes
- fix retain cycle in APIClient in `updateHost` method.

